### PR TITLE
Issue #9: Update vertical tab labels to exlude the word Fieldset.

### DIFF
--- a/styleguide.api.php
+++ b/styleguide.api.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Register a style guide element for display.
  *

--- a/styleguide.module
+++ b/styleguide.module
@@ -673,6 +673,8 @@ function styleguide_form($form, &$form_state, $form_keys = array()) {
   );
   foreach ($fieldsets as $fieldset) {
     $form['vertical_tabs'][$fieldset] = $form[$fieldset];
+    $title = styleguide_word() . ' ' . styleguide_word() . ' ' . styleguide_word();
+    $form['vertical_tabs'][$fieldset]['#title'] = $title;
   }
   $form['markup'] = array(
     '#markup' => t('<p><em>Markup</em>: Note that markup does not allow titles or descriptions. Use "item" for those options.</p>') . styleguide_paragraph(1),


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/styleguide/issues/9
